### PR TITLE
Add value_type using for the contained type

### DIFF
--- a/synchronized_value/synchronized_value.h
+++ b/synchronized_value/synchronized_value.h
@@ -24,6 +24,9 @@ template <typename GuardedType> class synchronized_value {
   GuardedType guarded_data_;
 
 public:
+
+  using value_type = GuardedType;
+
   synchronized_value(synchronized_value const &) = delete;
   auto operator=(synchronized_value const &) -> synchronized_value & = delete;
 

--- a/tests/synchronized_value_tests.cpp
+++ b/tests/synchronized_value_tests.cpp
@@ -5,6 +5,7 @@
 static_assert(std::is_nothrow_move_assignable_v<update_guard<int>>);
 static_assert(std::is_nothrow_move_constructible_v<update_guard<int>>);
 static_assert(std::is_nothrow_swappable_v<update_guard<int>>);
+static_assert(std::is_same_v<synchronized_value<int>::value_type,int>);
 
 TEST(synchronized_value_tests, star_operator) {
   synchronized_value<int> sv{5};


### PR DESCRIPTION
Add 
`using value type = GuardedType`
I used value_type as that seem to be the standard library convention